### PR TITLE
Support mailto property of cron_d resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ how to handle them, pre-populated as in the default AIDE config file.
 * `node["aide"]["report_url"]` - Where to send the output.  Defaults to "stdout". 
 See the AIDE documentation for other options.
 
+* `node["aide"]["cron_mailto"]` - Where to send the cron jobs' output. Either a
+string or the value `nil`. Defaults to `nil` (i.e. mail cron job output to the
+user the cron job _runs as_).
+
 Usage
 =====
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -13,6 +13,7 @@ default['aide']['dbdir'] = '/var/lib/aide'
 default['aide']['gzip'] = 'yes'
 default['aide']['report_url'] = 'stdout'
 default['aide']['verbose'] = '5'
+default['aide']['cron_mailto'] = nil
 
 case node['platform_family']
 when 'rhel'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -11,6 +11,7 @@ cron_d 'aide' do
   minute '30'
   user 'root'
   command "#{node['aide']['binary']} #{node['aide']['extra_parameters']} --check -V3"
+  mailto node['aide']['cron_mailto'] if node['aide']['cron_mailto']
 end
 
 cron_d 'aide-detailed' do
@@ -20,6 +21,7 @@ cron_d 'aide-detailed' do
   weekday '1'
   user 'root'
   command "#{node['aide']['binary']} #{node['aide']['extra_parameters']} --check -V5"
+  mailto node['aide']['cron_mailto'] if node['aide']['cron_mailto']
 end
 
 bash 'generate_database' do


### PR DESCRIPTION
This allows people to send the cron mail to someone other than the user the cron job is running as.