### PR TITLE
fix Amazon Linux support

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,8 +15,7 @@ default['aide']['report_url'] = 'stdout'
 default['aide']['verbose'] = '5'
 default['aide']['cron_mailto'] = nil
 
-case node['platform_family']
-when 'rhel'
+if platform_family?('rhel', 'amazon')
   default['aide']['binary'] = '/usr/sbin/aide'
   default['aide']['config'] = '/etc/aide.conf'
   default['aide']['extra_parameters'] = ''


### PR DESCRIPTION
Fixes #13.

# What

Corrects our RHEL-family check to include Amazon Linux.
